### PR TITLE
Add methodology link to footer

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -150,6 +150,7 @@ export default function Footer() {
             <li><a href="/about" className="hover:underline">About Us</a></li>
             <li><a href="/contact" className="hover:underline">Contact</a></li>
             <li><a href="/faq" className="hover:underline">FAQs</a></li>
+            <li><a href="/methodology" className="hover:underline">Methodology</a></li>
             <li><a href="/privacy-policy" className="hover:underline">Privacy Policy</a></li>
             <li><a href="/terms-conditions" className="hover:underline">Terms & Conditions</a></li>
           </ul>


### PR DESCRIPTION
## Summary
- add link to methodology page in footer quick links

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9d08630a083248f072a2ebdc19374