### PR TITLE
Add curated countries page and fix country route params

### DIFF
--- a/client/src/app/countries/page.tsx
+++ b/client/src/app/countries/page.tsx
@@ -1,136 +1,122 @@
-'use client';
-
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import Image from 'next/image';
 
-type CountryEntry = {
-  iso3: string;
-  name: string;
-  files: { narrative: string };
-  has_api?: boolean;
-  updated_at?: string;
-};
+type Country = { code: string; name: string };
 
-type Manifest = {
-  version: 'v1';
-  generated_at: string;
-  countries: CountryEntry[];
-};
-
-const countryGroups = [
+const GROUPS: { id: string; title: string; countries: Country[] }[] = [
   {
-    id: 'digital-nomad',
-    title: 'Digital Nomad Hotspots',
-    image: '/digital-nomad.jpg',
-    countries: ['Portugal', 'Estonia', 'Thailand'],
+    id: 'EU27',
+    title: 'EU27',
+    countries: [
+      { code: 'AUT', name: 'Austria' },
+      { code: 'BEL', name: 'Belgium' },
+      { code: 'BGR', name: 'Bulgaria' },
+      { code: 'HRV', name: 'Croatia' },
+      { code: 'CYP', name: 'Cyprus' },
+      { code: 'CZE', name: 'Czech Republic' },
+      { code: 'DNK', name: 'Denmark' },
+      { code: 'EST', name: 'Estonia' },
+      { code: 'FIN', name: 'Finland' },
+      { code: 'FRA', name: 'France' },
+      { code: 'DEU', name: 'Germany' },
+      { code: 'GRC', name: 'Greece' },
+      { code: 'HUN', name: 'Hungary' },
+      { code: 'IRL', name: 'Ireland' },
+      { code: 'ITA', name: 'Italy' },
+      { code: 'LVA', name: 'Latvia' },
+      { code: 'LTU', name: 'Lithuania' },
+      { code: 'LUX', name: 'Luxembourg' },
+      { code: 'MLT', name: 'Malta' },
+      { code: 'NLD', name: 'Netherlands' },
+      { code: 'POL', name: 'Poland' },
+      { code: 'PRT', name: 'Portugal' },
+      { code: 'ROU', name: 'Romania' },
+      { code: 'SVK', name: 'Slovakia' },
+      { code: 'SVN', name: 'Slovenia' },
+      { code: 'ESP', name: 'Spain' },
+      { code: 'SWE', name: 'Sweden' },
+    ],
   },
   {
-    id: 'expat-family',
-    title: 'Expat Family Friendly',
-    image: '/expat-family.jpg',
-    countries: ['Canada', 'New Zealand', 'Netherlands'],
+    id: 'EFTA',
+    title: 'EFTA',
+    countries: [
+      { code: 'ISL', name: 'Iceland' },
+      { code: 'LIE', name: 'Liechtenstein' },
+      { code: 'NOR', name: 'Norway' },
+      { code: 'CHE', name: 'Switzerland' },
+    ],
+  },
+  {
+    id: 'UK',
+    title: 'UK',
+    countries: [{ code: 'GBR', name: 'United Kingdom' }],
+  },
+  {
+    id: 'WBALK',
+    title: 'WBALK',
+    countries: [
+      { code: 'ALB', name: 'Albania' },
+      { code: 'BIH', name: 'Bosnia and Herzegovina' },
+      { code: 'MNE', name: 'Montenegro' },
+      { code: 'MKD', name: 'North Macedonia' },
+      { code: 'SRB', name: 'Serbia' },
+      { code: 'XKX', name: 'Kosovo' },
+    ],
+  },
+  {
+    id: 'E_NEI',
+    title: 'E_NEI',
+    countries: [
+      { code: 'UKR', name: 'Ukraine' },
+      { code: 'MDA', name: 'Moldova' },
+      { code: 'BLR', name: 'Belarus' },
+      { code: 'RUS', name: 'Russia' },
+      { code: 'TUR', name: 'Turkey' },
+    ],
+  },
+  {
+    id: 'CAUC',
+    title: 'CAUC',
+    countries: [
+      { code: 'ARM', name: 'Armenia' },
+      { code: 'AZE', name: 'Azerbaijan' },
+      { code: 'GEO', name: 'Georgia' },
+    ],
+  },
+  {
+    id: 'MICRO',
+    title: 'MICRO',
+    countries: [
+      { code: 'AND', name: 'Andorra' },
+      { code: 'MCO', name: 'Monaco' },
+      { code: 'SMR', name: 'San Marino' },
+    ],
   },
 ];
 
+const combinedCodes = GROUPS.flatMap((g) => g.countries.map((c) => c.code));
+
 export default function CountriesPage() {
-  const [data, setData] = useState<Manifest | null>(null);
-  const [err, setErr] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch('/data/v1/index.json')
-      .then((r) => (r.ok ? r.json() : Promise.reject(`${r.status} ${r.statusText}`)))
-      .then(setData)
-      .catch((e) => setErr(String(e)));
-  }, []);
-
   return (
-    <main
-      className="py-16 px-4"
-      style={{ backgroundColor: 'var(--background)', color: 'var(--foreground)' }}
-    >
-      <div className="max-w-5xl mx-auto space-y-12">
-        {/* Curated groups section */}
-        <section>
-          <h1 className="text-3xl font-bold text-center mb-10">Curated Country Groups</h1>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {countryGroups.map((group) => (
-              <div
-                key={group.id}
-                className="rounded-2xl overflow-hidden shadow border border-gray-200 bg-white/80 dark:bg-black/20"
-              >
-                <div className="relative h-40 w-full">
-                  <Image src={group.image} alt={group.title} fill className="object-cover" />
-                </div>
-                <div className="p-6">
-                  <h2 className="text-xl font-semibold mb-4">{group.title}</h2>
-                  <ul className="space-y-1 text-sm">
-                    {group.countries.map((country) => (
-                      <li key={country}>{country}</li>
-                    ))}
-                  </ul>
-                </div>
-              </div>
+    <main className="max-w-3xl mx-auto p-6 space-y-8">
+      <h1 className="text-3xl font-bold">Country Groupings</h1>
+      {GROUPS.map((group) => (
+        <section key={group.id} className="space-y-2">
+          <h2 className="text-2xl font-semibold">{group.title}</h2>
+          <ul className="list-disc pl-6 space-y-1">
+            {group.countries.map((c) => (
+              <li key={c.code}>
+                <Link href={`/country/${c.code}`}>{c.code} – {c.name}</Link>
+              </li>
             ))}
-          </div>
+          </ul>
         </section>
-
-        {/* All countries (from index.json) */}
-<section className="max-w-5xl mx-auto w-full">
-  <div className="flex items-end justify-between gap-4 mb-4">
-    <h2 className="text-2xl font-semibold">All Countries</h2>
-    <input
-      placeholder="Search by name or ISO3…"
-      className="border rounded-md px-3 py-2 text-sm w-64"
-      onChange={(e) => {
-        const q = e.target.value.toLowerCase();
-        setData((prev) =>
-          prev
-            ? {
-                ...prev,
-                countries: prev.countries.map(c => ({ ...c, _hide:
-                  !(c.name.toLowerCase().includes(q) || c.iso3.toLowerCase().includes(q))
-                })),
-              }
-            : prev
-        );
-      }}
-    />
-  </div>
-
-  {err ? (
-    <div className="p-4 bg-red-50 border text-red-700 rounded">
-      Error loading countries: {err}
-    </div>
-  ) : !data ? (
-    <div>Loading countries…</div>
-  ) : (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {data.countries
-        .filter((c: any) => !c._hide)
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .map((c) => (
-          <div key={c.iso3} className="rounded-xl border shadow-sm p-4 bg-white/80 dark:bg-black/20">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="font-medium">{c.name}</h3>
-              <span className="text-xs px-2 py-0.5 rounded-full border">{c.iso3}</span>
-            </div>
-            <p className="text-xs text-gray-500 mb-3">
-              Updated {c.updated_at ?? '—'}
-            </p>
-            <div className="flex items-center justify-between">
-              {c.has_api ? <span className="text-xs px-2 py-1 rounded border">Live API</span> : <span />}
-              <Link className="text-sm text-blue-600 hover:underline" href={`/country/${c.iso3}`}>
-                Open →
-              </Link>
-            </div>
-          </div>
-        ))}
-    </div>
-  )}
-</section>
-
-      </div>
+      ))}
+      <section className="space-y-2">
+        <h2 className="text-2xl font-semibold">Combined Curated Set</h2>
+        <p>{combinedCodes.join(', ')}</p>
+      </section>
     </main>
   );
 }
+

--- a/client/src/app/country/[iso3]/page.tsx
+++ b/client/src/app/country/[iso3]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { use, useEffect, useState } from 'react';
 import Link from 'next/link';
 
 type Fact = {
@@ -21,8 +21,9 @@ type Narrative = {
   source_links?: { label?: string; url: string }[];
 };
 
-export default function CountryPage({ params }: { params: { iso3: string } }) {
-  const iso3 = (params.iso3 || '').toUpperCase();
+export default function CountryPage({ params }: { params: Promise<{ iso3: string }> }) {
+  const { iso3: rawIso3 } = use(params);
+  const iso3 = (rawIso3 || '').toUpperCase();
   const [data, setData] = useState<Narrative | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
@@ -49,7 +50,7 @@ export default function CountryPage({ params }: { params: { iso3: string } }) {
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold">{iso3}</h1>
         {/* simple markdown-ish rendering without extra deps */}
-        {data.summary_md ? (
+        {typeof data.summary_md === 'string' ? (
           <div className="prose whitespace-pre-wrap">{data.summary_md}</div>
         ) : null}
       </header>


### PR DESCRIPTION
## Summary
- list curated country groups with full names and links
- unwrap dynamic country route params using `use` and guard narrative summary

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab1ca586288324abc985c3490652a6