### PR TITLE
Add theme toggle with redesigned dark mode

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -16,11 +16,11 @@
 
 /* Dark Theme */
 [data-theme='dark'] {
-  --background: #0a0a0a; /* deep blue-gray */
-  --foreground: #ededed; /* light gray text */
-  --primary: #3b82f6; /* brighter blue */
-  --secondary: #facc15; /* yellow */
-  --accent: #34d399; /* minty green */
+  --background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  --foreground: #e2e8f0; /* light slate */
+  --primary: #6366f1; /* indigo */
+  --secondary: #a855f7; /* purple */
+  --accent: #14b8a6; /* teal */
 
   --font-sans: 'Geist Sans', sans-serif;
   --font-mono: 'Geist Mono', monospace;
@@ -42,7 +42,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), sans-serif;
-  transition: background-color 0.3s, color 0.3s ease;
+  transition: background 0.3s, color 0.3s ease;
 }
 
 

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,7 +1,8 @@
 
 import type { Metadata } from "next";
 import "./globals.css";
-import Navbar from "@/components/navbar"; // ✅ New import
+import Navbar from "@/components/navbar"; // ✅ Modular header
+import ThemeToggle from "@/components/ThemeToggle";
 
 
 
@@ -18,8 +19,8 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className="antialiased">
-        <Navbar /> {/* ✅ Modular header */}
-        
+        <Navbar />
+        <ThemeToggle />
         {children}
       </body>
     </html>

--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+      document.documentElement.setAttribute("data-theme", stored);
+      document.documentElement.classList.toggle("dark", stored === "dark");
+    } else {
+      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      const initial = prefersDark ? "dark" : "light";
+      setTheme(initial);
+      document.documentElement.setAttribute("data-theme", initial);
+      document.documentElement.classList.toggle("dark", initial === "dark");
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "dark" ? "light" : "dark";
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <button
+      className="theme-toggle-btn"
+      onClick={toggleTheme}
+      aria-label="Toggle dark mode"
+    >
+      {theme === "dark" ? "☀️" : "🌙"}
+    </button>
+  );
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,6 +1,6 @@
 // tailwind.config.js
 module.exports = {
-  darkMode: 'media',
+  darkMode: 'class',
   content: [
     './src/app/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- allow users to switch between light and dark themes with a toggle button
- apply gradient-based dark theme styling and smooth transitions
- configure Tailwind for class-based dark mode handling

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68abb81571c08324bc89cf903de7dc39