### PR TITLE
feat: add neon footer theme toggle

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -16,11 +16,11 @@
 
 /* Dark Theme */
 [data-theme='dark'] {
-  --background: #0a0a0a; /* deep blue-gray */
-  --foreground: #ededed; /* light gray text */
-  --primary: #3b82f6; /* brighter blue */
-  --secondary: #facc15; /* yellow */
-  --accent: #34d399; /* minty green */
+  --background: #0b0e17; /* midnight asphalt */
+  --foreground: #e2e8f0; /* misty gray */
+  --primary: #0ea5e9; /* neon cyan */
+  --secondary: #d946ef; /* vibrant magenta */
+  --accent: #64748b; /* urban smoke */
 
   --font-sans: 'Geist Sans', sans-serif;
   --font-mono: 'Geist Mono', monospace;
@@ -43,25 +43,6 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), sans-serif;
   transition: background-color 0.3s, color 0.3s ease;
-}
-
-
-/* Button for Theme Toggle (Example) */
-.theme-toggle-btn {
-  position: fixed;
-  top: 20px;
-  right: 20px;
-  padding: 10px 20px;
-  background-color: var(--primary);
-  color: white;
-  border: none;
-  border-radius: 5px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-}
-
-.theme-toggle-btn:hover {
-  background-color: var(--secondary);
 }
 
 @media (max-width: 768px) {

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useRef } from "react";
 import { motion } from "framer-motion";
 import { FaLinkedin, FaInstagram, FaFacebook } from "react-icons/fa";
+import ThemeToggle from "./ThemeToggle";
 
 export default function Footer() {
   // State & refs for running icons and messages
@@ -225,6 +226,10 @@ export default function Footer() {
           </div>
           <p className="text-xs text-gray-200">&copy; {new Date().getFullYear()} Inquos. All rights reserved.</p>
         </motion.div>
+      </div>
+
+      <div className="mt-10 flex justify-center">
+        <ThemeToggle />
       </div>
 
       <style jsx>{`

--- a/client/src/components/ThemeToggle.tsx
+++ b/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const stored = (localStorage.getItem("theme") as "light" | "dark" | null);
+    const preferred =
+      stored ?? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+
+    setTheme(preferred);
+    document.documentElement.setAttribute("data-theme", preferred);
+    document.documentElement.classList.toggle("dark", preferred === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.documentElement.setAttribute("data-theme", next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle dark mode"
+      className={`relative w-12 h-6 rounded-full transition-colors duration-300 focus:outline-none ${
+        theme === "dark" ? "bg-[var(--secondary)]" : "bg-gray-300"
+      }`}
+    >
+      <span
+        className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow-md transition-transform duration-300 ${
+          theme === "dark" ? "translate-x-6 bg-[var(--primary)]" : ""
+        }`}
+      />
+    </button>
+  );
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,6 +1,6 @@
 // tailwind.config.js
 module.exports = {
-  darkMode: 'media',
+  darkMode: 'class',
   content: [
     './src/app/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- add minimalistic theme toggle in footer
- switch tailwind to class-based dark mode and apply neon night palette

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abbac0c13c8324a8c51b58ea4fe3fa