### PR TITLE
Add footer globally and refine dark mode styling

### DIFF
--- a/client/src/app/countries/page.tsx
+++ b/client/src/app/countries/page.tsx
@@ -179,25 +179,25 @@ export default function CountriesPage() {
   }
 
   return (
-    <main className="max-w-6xl mx-auto p-6 space-y-10">
+    <main className="max-w-6xl mx-auto p-6 space-y-10 min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       {/* Hero / toolbar */}
-      <section className="rounded-2xl border p-6 bg-gradient-to-br from-slate-50 to-white ring-1 ring-inset ring-slate-200">
+      <section className="rounded-2xl border p-6 bg-gradient-to-br from-slate-50 to-white ring-1 ring-inset ring-slate-200 dark:from-slate-800 dark:to-gray-900 dark:border-gray-700 dark:ring-slate-700">
         <div className="flex flex-col md:flex-row md:items-end gap-4">
           <div className="flex-1">
             <h1 className="text-3xl font-semibold">Explore countries</h1>
-            <p className="text-sm text-gray-600 mt-1">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
               Browse Europe and neighbours. Click a country to open its brief.
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs px-2 py-1 rounded-full border bg-white">{shownCount}/{totalCount}</span>
+            <span className="text-xs px-2 py-1 rounded-full border bg-white dark:bg-gray-800 dark:border-gray-600">{shownCount}/{totalCount}</span>
             <label className="sr-only" htmlFor="country-search">Search</label>
             <input
               id="country-search"
               value={q}
               onChange={(e) => setQ(e.target.value)}
               placeholder="Search by country or ISO3…"
-              className="w-72 max-w-full border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              className="w-72 max-w-full border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
               autoComplete="off"
             />
           </div>
@@ -206,7 +206,7 @@ export default function CountriesPage() {
 
       {/* Groups */}
       {filtered.length === 0 ? (
-        <div className="p-6 text-gray-600 border rounded-xl bg-white">
+        <div className="p-6 text-gray-600 dark:text-gray-300 border rounded-xl bg-white dark:bg-gray-800 dark:border-gray-700">
           No countries match “{q}”. Try a different name or code.
         </div>
       ) : (
@@ -226,11 +226,12 @@ export default function CountriesPage() {
                   'w-full rounded-xl p-4 border bg-gradient-to-r flex items-center gap-3 text-left',
                   'transition focus:outline-none focus:ring-2',
                   accent.headerFrom, accent.headerTo, accent.ring,
+                  'dark:from-gray-800 dark:to-gray-700 dark:border-gray-700',
                 ].join(' ')}
               >
                 <Chevron open={isOpen} />
                 <span className="text-lg md:text-xl font-semibold">{group.title}</span>
-                <span className={['ml-auto text-xs px-2 py-0.5 rounded-full border', accent.chip].join(' ')}>
+                <span className={['ml-auto text-xs px-2 py-0.5 rounded-full border', accent.chip, 'dark:bg-gray-800 dark:border-gray-600'].join(' ')}>
                   {group.countries.length}
                 </span>
               </button>
@@ -251,6 +252,7 @@ export default function CountriesPage() {
                           'bg-gradient-to-br',
                           accent.hoverFrom,
                           accent.hoverTo,
+                          'dark:border-gray-700 dark:bg-gray-800 dark:hover:from-gray-700 dark:hover:to-gray-800',
                         ].join(' ')}
                         aria-label={`Open ${c.name}`}
                       >

--- a/client/src/app/country/[iso3]/page.tsx
+++ b/client/src/app/country/[iso3]/page.tsx
@@ -213,13 +213,13 @@ export default function CountryPage() {
   if (!data) return <div className="p-6">Loading {defaultName}…</div>;
 
   return (
-    <main className="max-w-6xl mx-auto p-6 space-y-8">
+    <main className="max-w-6xl mx-auto p-6 space-y-8 min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       {/* Breadcrumb with accent dot */}
-      <nav className="text-sm text-gray-600 flex items-center gap-2">
+      <nav className="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
         <span className={`inline-block h-2 w-2 rounded-full ${accent.bar}`} />
         <Link href="/countries" className="hover:underline">Countries</Link>
         <span className="opacity-60">/</span>
-        <span className="font-medium text-gray-800">{headerName}</span>
+        <span className="font-medium text-gray-800 dark:text-gray-200">{headerName}</span>
       </nav>
 
       {/* Header / hero with soft gradient + ring */}
@@ -230,20 +230,21 @@ export default function CountryPage() {
           accent.gradTo,
           'ring-1 ring-inset',
           accent.ring,
+          'dark:from-gray-800 dark:to-gray-900 dark:border-gray-700',
         ].join(' ')}
       >
         <div className="flex items-center gap-4">
           <div className="text-4xl leading-none">{flag}</div>
           <div className="min-w-0">
             <h1 className="text-3xl font-semibold truncate">{headerName} — Country Brief</h1>
-            <div className="mt-1 text-sm text-gray-700">
+            <div className="mt-1 text-sm text-gray-700 dark:text-gray-300">
               Data snapshot: {snapshot} • Dataset: World Bank (WDI & related)
             </div>
           </div>
-          <span className="ml-auto text-xs px-2 py-1 rounded-full border bg-white/70">{iso3}</span>
+          <span className="ml-auto text-xs px-2 py-1 rounded-full border bg-white/70 dark:bg-gray-800 dark:border-gray-600">{iso3}</span>
         </div>
         {data.summary_md ? (
-          <p className="mt-4 text-gray-800 whitespace-pre-wrap">{data.summary_md}</p>
+          <p className="mt-4 text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{data.summary_md}</p>
         ) : null}
       </header>
 
@@ -251,9 +252,9 @@ export default function CountryPage() {
       {factsOrdered.length ? (
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Headline KPIs (latest available)</h2>
-          <div className="overflow-auto rounded-2xl border bg-white/70">
+          <div className="overflow-auto rounded-2xl border bg-white/70 dark:bg-gray-800 dark:border-gray-700">
             <table className="min-w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr className="text-left">
                   <th className="px-4 py-3 font-medium">Indicator (code)</th>
                   <th className="px-4 py-3 font-medium">Value (year)</th>
@@ -271,10 +272,10 @@ export default function CountryPage() {
                   const worldPctTxt = pctile(worldPctRaw);
 
                   return (
-                    <tr key={`${f.code}-${i}`} className={i % 2 ? 'bg-gray-50/40' : ''}>
+                    <tr key={`${f.code}-${i}`} className={i % 2 ? 'bg-gray-50/40 dark:bg-gray-800/40' : ''}>
                       <td className="px-4 py-3 align-top">
                         <div className="font-medium">{meta.label}</div>
-                        <div className="text-xs text-gray-500">{f.code}</div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">{f.code}</div>
                       </td>
                       <td className="px-4 py-3 align-top">{value} {yr !== '—' ? `(${yr})` : ''}</td>
                       {hasAnyYoY ? (
@@ -291,7 +292,7 @@ export default function CountryPage() {
                           <span className={`inline-block text-xs px-2 py-0.5 rounded-full border ${accent.chip}`}>
                             {worldPctTxt}
                           </span>
-                          <div className="h-2 rounded bg-gray-200 w-32 overflow-hidden">
+                            <div className="h-2 rounded bg-gray-200 dark:bg-gray-700 w-32 overflow-hidden">
                             <div
                               className={['h-2 rounded', accent.bar].join(' ')}
                               style={{ width: worldPctRaw != null ? `${Math.max(0, Math.min(100, worldPctRaw))}%` : '0%' }}
@@ -300,14 +301,14 @@ export default function CountryPage() {
                           </div>
                         </div>
                       </td>
-                      <td className="px-4 py-3 align-top text-gray-700">{meta.notes ?? ''}</td>
+                      <td className="px-4 py-3 align-top text-gray-700 dark:text-gray-300">{meta.notes ?? ''}</td>
                     </tr>
                   );
                 })}
               </tbody>
             </table>
           </div>
-          <p className="text-xs text-gray-600">
+            <p className="text-xs text-gray-600 dark:text-gray-400">
             Benchmarks: world percentile shown above; region & income-group percentiles available per series when included.
           </p>
         </section>
@@ -323,6 +324,7 @@ export default function CountryPage() {
                 'rounded-2xl border p-4 bg-gradient-to-br',
                 accent.gradFrom,
                 'to-white',
+                'dark:from-gray-800 dark:to-gray-900 dark:border-gray-700',
               ].join(' ')}
             >
               <h3 className="text-lg font-semibold mb-1">
@@ -348,12 +350,12 @@ export default function CountryPage() {
               const title = k.replace('_', ' ').replace(/\b\w/g, (s) => s.toUpperCase());
 
               return (
-                <div key={k} className={`rounded-2xl border p-4 bg-white/70 ring-1 ring-inset ${accent.ring}`}>
+                <div key={k} className={`rounded-2xl border p-4 bg-white/70 dark:bg-gray-800 dark:border-gray-700 ring-1 ring-inset ${accent.ring} dark:ring-gray-700`}>
                   <div className="flex items-baseline justify-between mb-2">
                     <h3 className="font-medium">{title}</h3>
                     <div className="text-2xl font-semibold">{scoreText}</div>
                   </div>
-                  <div className="h-2 rounded bg-gray-200 overflow-hidden mb-3" aria-hidden>
+                  <div className="h-2 rounded bg-gray-200 dark:bg-gray-700 overflow-hidden mb-3" aria-hidden>
                     <div
                       className={['h-2 rounded', accent.bar].join(' ')}
                       style={{ width: scoreNum != null ? `${Math.max(0, Math.min(100, scoreNum))}%` : '0%' }}
@@ -375,12 +377,12 @@ export default function CountryPage() {
           <h2 className="text-xl font-semibold">Callouts</h2>
           <div className="flex flex-wrap gap-2">
             {(data.callouts?.strengths ?? []).map((s, i) => (
-              <span key={`s-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip}`}>
+              <span key={`s-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip} dark:bg-gray-800 dark:border-gray-600`}>
                 ✅ {s.label ?? s.code ?? 'Strength'}
               </span>
             ))}
             {(data.callouts?.watchouts ?? []).map((w, i) => (
-              <span key={`w-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip}`}>
+              <span key={`w-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip} dark:bg-gray-800 dark:border-gray-600`}>
                 ⚠️ {w.label ?? w.code ?? 'Watch-out'}
               </span>
             ))}
@@ -395,7 +397,7 @@ export default function CountryPage() {
           <ul className="list-disc pl-6 space-y-1">
             {Object.entries(data.source_links).map(([code, url]) => (
               <li key={code}>
-                <a className="text-blue-600 hover:underline" href={url} target="_blank" rel="noreferrer">
+                <a className="text-blue-600 dark:text-blue-400 hover:underline" href={url} target="_blank" rel="noreferrer">
                   {code} — {INDICATORS[code]?.label ?? 'Indicator'}
                 </a>
               </li>

--- a/client/src/app/jobs/JobsClient.tsx
+++ b/client/src/app/jobs/JobsClient.tsx
@@ -88,7 +88,7 @@ export default function JobsPage() {
         <button
           key={i}
           onClick={() => handlePageChange(i)}
-          className={`px-3 py-1 border rounded ${currentPage === i ? 'bg-black text-white' : ''}`}
+          className={`px-3 py-1 border rounded border-gray-300 dark:border-gray-600 ${currentPage === i ? 'bg-black text-white dark:bg-white dark:text-black' : ''}`}
         >
           {i}
         </button>
@@ -102,7 +102,7 @@ export default function JobsPage() {
         <button
           key={totalPages}
           onClick={() => handlePageChange(totalPages)}
-          className={`px-3 py-1 border rounded ${currentPage === totalPages ? 'bg-black text-white' : ''}`}
+          className={`px-3 py-1 border rounded border-gray-300 dark:border-gray-600 ${currentPage === totalPages ? 'bg-black text-white dark:bg-white dark:text-black' : ''}`}
         >
           {totalPages}
         </button>
@@ -113,24 +113,24 @@ export default function JobsPage() {
   };
 
   return (
-    <main className="max-w-5xl mx-auto px-4 py-8">
+    <main className="max-w-5xl mx-auto px-4 py-8 min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       {/* Removed the <h1> "Remote Jobs" */}
 
       {loading ? (
-        <p className="text-gray-600">Loading...</p>
+        <p className="text-gray-600 dark:text-gray-300">Loading...</p>
       ) : jobs.length === 0 ? (
-        <p className="text-red-500">No jobs found.</p>
+        <p className="text-red-500 dark:text-red-400">No jobs found.</p>
       ) : (
         <div className="flex flex-col gap-4 mb-8">
           {jobs.map((job) => {
             const isExpanded = expandedJobId === job.id;
 
             return (
-              <div
-                key={job.id}
-                onClick={() => toggleExpand(job.id)}
-                className="border rounded-xl p-4 cursor-pointer hover:shadow transition"
-              >
+                <div
+                  key={job.id}
+                  onClick={() => toggleExpand(job.id)}
+                  className="border border-gray-200 dark:border-gray-700 rounded-xl p-4 cursor-pointer hover:shadow transition bg-white dark:bg-gray-800"
+                >
                 <div className="flex justify-between items-center mb-2">
                   {/* Left side: Title and company logo */}
                   <div className="flex items-center gap-3">
@@ -145,14 +145,14 @@ export default function JobsPage() {
                   </div>
 
                   {/* Right side: publication date */}
-                  <span className="text-sm text-gray-500">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
                     {new Date(job.publication_date).toLocaleDateString()}
                   </span>
                 </div>
 
                 {/* Collapsed view info */}
-                {!isExpanded && (
-                  <div className="text-sm text-gray-600 flex flex-wrap gap-4">
+                  {!isExpanded && (
+                    <div className="text-sm text-gray-600 dark:text-gray-300 flex flex-wrap gap-4">
                     <span>{job.candidate_required_location}</span>
                     <span>{job.job_type}</span>
                     {job.salary && <span>{job.salary}</span>}
@@ -162,10 +162,10 @@ export default function JobsPage() {
                 {/* Expanded view */}
                 {isExpanded && (
                   <>
-                    <p className="text-gray-700 mt-2">
+                      <p className="text-gray-700 dark:text-gray-300 mt-2">
                       <strong>Company:</strong> {job.company_name}
                     </p>
-                    <p className="text-gray-700">
+                      <p className="text-gray-700 dark:text-gray-300">
                       <strong>Category:</strong> {job.category}
                     </p>
 
@@ -173,10 +173,10 @@ export default function JobsPage() {
                     {job.tags && job.tags.length > 0 && (
                       <div className="mt-2 flex flex-wrap gap-2">
                         {job.tags.map((tag, idx) => (
-                          <span
-                            key={idx}
-                            className="bg-gray-200 text-gray-700 text-xs px-2 py-1 rounded-full"
-                          >
+                            <span
+                              key={idx}
+                              className="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs px-2 py-1 rounded-full"
+                            >
                             {tag}
                           </span>
                         ))}
@@ -184,10 +184,10 @@ export default function JobsPage() {
                     )}
 
                     {/* Description */}
-                    <div
-                      className="mt-4 text-gray-700 max-h-96 overflow-auto"
-                      dangerouslySetInnerHTML={{ __html: job.description }}
-                    />
+                      <div
+                        className="mt-4 text-gray-700 dark:text-gray-300 max-h-96 overflow-auto"
+                        dangerouslySetInnerHTML={{ __html: job.description }}
+                      />
 
                     {/* Button */}
                     <div className="mt-4">
@@ -195,7 +195,7 @@ export default function JobsPage() {
                         href={job.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+                          className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition"
                         onClick={(e) => e.stopPropagation()} // prevent card toggle on click
                       >
                         See the job posting
@@ -210,22 +210,22 @@ export default function JobsPage() {
       )}
 
       {/* Pagination Controls */}
-      <div className="flex justify-center items-center gap-2">
-        <button
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage <= 1}
-          className="px-4 py-2 border rounded disabled:opacity-50"
-        >
+        <div className="flex justify-center items-center gap-2">
+          <button
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage <= 1}
+            className="px-4 py-2 border rounded border-gray-300 dark:border-gray-600 disabled:opacity-50"
+          >
           Previous
         </button>
 
         {renderPageNumbers()}
 
-        <button
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={currentPage >= totalPages}
-          className="px-4 py-2 border rounded disabled:opacity-50"
-        >
+          <button
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage >= totalPages}
+            className="px-4 py-2 border rounded border-gray-300 dark:border-gray-600 disabled:opacity-50"
+          >
           Next
         </button>
       </div>

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,7 +1,8 @@
 
 import type { Metadata } from "next";
 import "./globals.css";
-import Navbar from "@/components/navbar"; // ✅ New import
+import Navbar from "@/components/navbar"; // ✅ Modular header
+import Footer from "@/components/Footer";
 
 
 
@@ -17,10 +18,12 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
-        <Navbar /> {/* ✅ Modular header */}
-        
-        {children}
+      <body className="antialiased flex min-h-screen flex-col">
+        <Navbar />
+
+        <div className="flex-1">{children}</div>
+
+        <Footer />
       </body>
     </html>
   );

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -6,7 +6,6 @@ import SearchMe from "@/components/SearchMe";
 import HowItWorks from "@/components/HowItWorks";
 import Contact from "@/components/Contact";
 import CoreServices from "@/components/CoreServices";
-import Footer from "@/components/Footer";
 
 // Dynamically import WorldMap for client-side only
 const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
@@ -45,11 +44,6 @@ export default function Home() {
         <Contact />
       </section>
 
-
-      {/* Footer Section */}
-      <footer id="footer">
-        <Footer />
-      </footer>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- include shared footer in root layout and remove duplicate from homepage
- adjust jobs, countries and country detail pages for proper dark mode styling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abbe5162c88324a80d970f623511b8