### PR TITLE
Improve dark mode contrast and credit World Bank API

### DIFF
--- a/client/src/app/about/page.tsx
+++ b/client/src/app/about/page.tsx
@@ -1,6 +1,9 @@
+import Footer from "@/components/Footer";
+
 export default function AboutPage() {
   return (
-    <main className="max-w-5xl mx-auto px-6 py-16 text-base leading-relaxed">
+    <>
+      <main className="max-w-5xl mx-auto px-6 py-16 text-base leading-relaxed">
       <h1 className="text-4xl font-bold mb-10">About Us</h1>
 
       <section className="mb-16">
@@ -32,11 +35,16 @@ export default function AboutPage() {
           <li>
             <strong>MapLibre:</strong> Powering our interactive maps with accurate, open-source geographic data to support your relocation and remote work decisions.
           </li>
+          <li>
+            <strong>World Bank API:</strong> Supplying global development and economic data for broader context.
+          </li>
         </ul>
         <p>
           Together, these partners enable us to cut through the noise and deliver clear, aligned guidance — helping you take confident steps toward your future.
         </p>
       </section>
-    </main>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/client/src/app/countries/page.tsx
+++ b/client/src/app/countries/page.tsx
@@ -3,6 +3,7 @@
 import type React from 'react';
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import Footer from "@/components/Footer";
 
 type Country = { code: string; name: string };
 type Group = { id: string; title: string; countries: Country[] };
@@ -179,25 +180,26 @@ export default function CountriesPage() {
   }
 
   return (
-    <main className="max-w-6xl mx-auto p-6 space-y-10">
+    <>
+      <main className="max-w-6xl mx-auto p-6 space-y-10 min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       {/* Hero / toolbar */}
-      <section className="rounded-2xl border p-6 bg-gradient-to-br from-slate-50 to-white ring-1 ring-inset ring-slate-200">
+      <section className="rounded-2xl border p-6 bg-gradient-to-br from-slate-50 to-white ring-1 ring-inset ring-slate-200 dark:from-slate-800 dark:to-gray-900 dark:border-gray-700 dark:ring-slate-700">
         <div className="flex flex-col md:flex-row md:items-end gap-4">
           <div className="flex-1">
             <h1 className="text-3xl font-semibold">Explore countries</h1>
-            <p className="text-sm text-gray-600 mt-1">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
               Browse Europe and neighbours. Click a country to open its brief.
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <span className="text-xs px-2 py-1 rounded-full border bg-white">{shownCount}/{totalCount}</span>
+            <span className="text-xs px-2 py-1 rounded-full border bg-white dark:bg-gray-800 dark:border-gray-600">{shownCount}/{totalCount}</span>
             <label className="sr-only" htmlFor="country-search">Search</label>
             <input
               id="country-search"
               value={q}
               onChange={(e) => setQ(e.target.value)}
               placeholder="Search by country or ISO3…"
-              className="w-72 max-w-full border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              className="w-72 max-w-full border rounded-xl px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200"
               autoComplete="off"
             />
           </div>
@@ -206,7 +208,7 @@ export default function CountriesPage() {
 
       {/* Groups */}
       {filtered.length === 0 ? (
-        <div className="p-6 text-gray-600 border rounded-xl bg-white">
+        <div className="p-6 text-gray-600 dark:text-gray-300 border rounded-xl bg-white dark:bg-gray-800 dark:border-gray-700">
           No countries match “{q}”. Try a different name or code.
         </div>
       ) : (
@@ -226,11 +228,12 @@ export default function CountriesPage() {
                   'w-full rounded-xl p-4 border bg-gradient-to-r flex items-center gap-3 text-left',
                   'transition focus:outline-none focus:ring-2',
                   accent.headerFrom, accent.headerTo, accent.ring,
+                  'dark:from-gray-800 dark:to-gray-700 dark:border-gray-700',
                 ].join(' ')}
               >
                 <Chevron open={isOpen} />
                 <span className="text-lg md:text-xl font-semibold">{group.title}</span>
-                <span className={['ml-auto text-xs px-2 py-0.5 rounded-full border', accent.chip].join(' ')}>
+                <span className={['ml-auto text-xs px-2 py-0.5 rounded-full border', accent.chip, 'dark:bg-gray-800 dark:border-gray-600'].join(' ')}>
                   {group.countries.length}
                 </span>
               </button>
@@ -251,6 +254,8 @@ export default function CountriesPage() {
                           'bg-gradient-to-br',
                           accent.hoverFrom,
                           accent.hoverTo,
+                          'dark:border-gray-700 dark:from-gray-800 dark:to-gray-800 dark:text-gray-200',
+                          'dark:hover:from-gray-700 dark:hover:to-gray-800',
                         ].join(' ')}
                         aria-label={`Open ${c.name}`}
                       >
@@ -268,6 +273,8 @@ export default function CountriesPage() {
           );
         })
       )}
-    </main>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/client/src/app/country/[iso3]/page.tsx
+++ b/client/src/app/country/[iso3]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import Footer from "@/components/Footer";
 
 /** ---------- Types matching your narrative JSON ---------- */
 type Pctl = { world?: number; region?: number; income?: number };
@@ -213,13 +214,14 @@ export default function CountryPage() {
   if (!data) return <div className="p-6">Loading {defaultName}…</div>;
 
   return (
-    <main className="max-w-6xl mx-auto p-6 space-y-8">
+    <>
+      <main className="max-w-6xl mx-auto p-6 space-y-8 min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       {/* Breadcrumb with accent dot */}
-      <nav className="text-sm text-gray-600 flex items-center gap-2">
+      <nav className="text-sm text-gray-600 dark:text-gray-300 flex items-center gap-2">
         <span className={`inline-block h-2 w-2 rounded-full ${accent.bar}`} />
         <Link href="/countries" className="hover:underline">Countries</Link>
         <span className="opacity-60">/</span>
-        <span className="font-medium text-gray-800">{headerName}</span>
+        <span className="font-medium text-gray-800 dark:text-gray-200">{headerName}</span>
       </nav>
 
       {/* Header / hero with soft gradient + ring */}
@@ -230,20 +232,21 @@ export default function CountryPage() {
           accent.gradTo,
           'ring-1 ring-inset',
           accent.ring,
+          'dark:from-gray-800 dark:to-gray-900 dark:border-gray-700',
         ].join(' ')}
       >
         <div className="flex items-center gap-4">
           <div className="text-4xl leading-none">{flag}</div>
           <div className="min-w-0">
             <h1 className="text-3xl font-semibold truncate">{headerName} — Country Brief</h1>
-            <div className="mt-1 text-sm text-gray-700">
+            <div className="mt-1 text-sm text-gray-700 dark:text-gray-300">
               Data snapshot: {snapshot} • Dataset: World Bank (WDI & related)
             </div>
           </div>
-          <span className="ml-auto text-xs px-2 py-1 rounded-full border bg-white/70">{iso3}</span>
+          <span className="ml-auto text-xs px-2 py-1 rounded-full border bg-white/70 dark:bg-gray-800 dark:border-gray-600">{iso3}</span>
         </div>
         {data.summary_md ? (
-          <p className="mt-4 text-gray-800 whitespace-pre-wrap">{data.summary_md}</p>
+          <p className="mt-4 text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{data.summary_md}</p>
         ) : null}
       </header>
 
@@ -251,9 +254,9 @@ export default function CountryPage() {
       {factsOrdered.length ? (
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Headline KPIs (latest available)</h2>
-          <div className="overflow-auto rounded-2xl border bg-white/70">
+          <div className="overflow-auto rounded-2xl border bg-white/70 dark:bg-gray-800 dark:border-gray-700">
             <table className="min-w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr className="text-left">
                   <th className="px-4 py-3 font-medium">Indicator (code)</th>
                   <th className="px-4 py-3 font-medium">Value (year)</th>
@@ -271,10 +274,10 @@ export default function CountryPage() {
                   const worldPctTxt = pctile(worldPctRaw);
 
                   return (
-                    <tr key={`${f.code}-${i}`} className={i % 2 ? 'bg-gray-50/40' : ''}>
+                    <tr key={`${f.code}-${i}`} className={i % 2 ? 'bg-gray-50/40 dark:bg-gray-800/40' : ''}>
                       <td className="px-4 py-3 align-top">
                         <div className="font-medium">{meta.label}</div>
-                        <div className="text-xs text-gray-500">{f.code}</div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">{f.code}</div>
                       </td>
                       <td className="px-4 py-3 align-top">{value} {yr !== '—' ? `(${yr})` : ''}</td>
                       {hasAnyYoY ? (
@@ -291,7 +294,7 @@ export default function CountryPage() {
                           <span className={`inline-block text-xs px-2 py-0.5 rounded-full border ${accent.chip}`}>
                             {worldPctTxt}
                           </span>
-                          <div className="h-2 rounded bg-gray-200 w-32 overflow-hidden">
+                            <div className="h-2 rounded bg-gray-200 dark:bg-gray-700 w-32 overflow-hidden">
                             <div
                               className={['h-2 rounded', accent.bar].join(' ')}
                               style={{ width: worldPctRaw != null ? `${Math.max(0, Math.min(100, worldPctRaw))}%` : '0%' }}
@@ -300,14 +303,14 @@ export default function CountryPage() {
                           </div>
                         </div>
                       </td>
-                      <td className="px-4 py-3 align-top text-gray-700">{meta.notes ?? ''}</td>
+                      <td className="px-4 py-3 align-top text-gray-700 dark:text-gray-300">{meta.notes ?? ''}</td>
                     </tr>
                   );
                 })}
               </tbody>
             </table>
           </div>
-          <p className="text-xs text-gray-600">
+            <p className="text-xs text-gray-600 dark:text-gray-400">
             Benchmarks: world percentile shown above; region & income-group percentiles available per series when included.
           </p>
         </section>
@@ -323,6 +326,7 @@ export default function CountryPage() {
                 'rounded-2xl border p-4 bg-gradient-to-br',
                 accent.gradFrom,
                 'to-white',
+                'dark:from-gray-800 dark:to-gray-900 dark:border-gray-700',
               ].join(' ')}
             >
               <h3 className="text-lg font-semibold mb-1">
@@ -348,12 +352,12 @@ export default function CountryPage() {
               const title = k.replace('_', ' ').replace(/\b\w/g, (s) => s.toUpperCase());
 
               return (
-                <div key={k} className={`rounded-2xl border p-4 bg-white/70 ring-1 ring-inset ${accent.ring}`}>
+                <div key={k} className={`rounded-2xl border p-4 bg-white/70 dark:bg-gray-800 dark:border-gray-700 ring-1 ring-inset ${accent.ring} dark:ring-gray-700`}>
                   <div className="flex items-baseline justify-between mb-2">
                     <h3 className="font-medium">{title}</h3>
                     <div className="text-2xl font-semibold">{scoreText}</div>
                   </div>
-                  <div className="h-2 rounded bg-gray-200 overflow-hidden mb-3" aria-hidden>
+                  <div className="h-2 rounded bg-gray-200 dark:bg-gray-700 overflow-hidden mb-3" aria-hidden>
                     <div
                       className={['h-2 rounded', accent.bar].join(' ')}
                       style={{ width: scoreNum != null ? `${Math.max(0, Math.min(100, scoreNum))}%` : '0%' }}
@@ -375,12 +379,12 @@ export default function CountryPage() {
           <h2 className="text-xl font-semibold">Callouts</h2>
           <div className="flex flex-wrap gap-2">
             {(data.callouts?.strengths ?? []).map((s, i) => (
-              <span key={`s-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip}`}>
+              <span key={`s-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip} dark:bg-gray-800 dark:border-gray-600`}>
                 ✅ {s.label ?? s.code ?? 'Strength'}
               </span>
             ))}
             {(data.callouts?.watchouts ?? []).map((w, i) => (
-              <span key={`w-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip}`}>
+              <span key={`w-${i}`} className={`text-xs px-2 py-1 rounded-full border ${accent.chip} dark:bg-gray-800 dark:border-gray-600`}>
                 ⚠️ {w.label ?? w.code ?? 'Watch-out'}
               </span>
             ))}
@@ -395,7 +399,7 @@ export default function CountryPage() {
           <ul className="list-disc pl-6 space-y-1">
             {Object.entries(data.source_links).map(([code, url]) => (
               <li key={code}>
-                <a className="text-blue-600 hover:underline" href={url} target="_blank" rel="noreferrer">
+                <a className="text-blue-600 dark:text-blue-400 hover:underline" href={url} target="_blank" rel="noreferrer">
                   {code} — {INDICATORS[code]?.label ?? 'Indicator'}
                 </a>
               </li>
@@ -403,6 +407,8 @@ export default function CountryPage() {
           </ul>
         </section>
       ) : null}
-    </main>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/client/src/app/jobs/JobsClient.tsx
+++ b/client/src/app/jobs/JobsClient.tsx
@@ -88,7 +88,7 @@ export default function JobsPage() {
         <button
           key={i}
           onClick={() => handlePageChange(i)}
-          className={`px-3 py-1 border rounded ${currentPage === i ? 'bg-black text-white' : ''}`}
+          className={`px-3 py-1 border rounded border-gray-300 dark:border-gray-600 ${currentPage === i ? 'bg-black text-white dark:bg-white dark:text-black' : ''}`}
         >
           {i}
         </button>
@@ -102,7 +102,7 @@ export default function JobsPage() {
         <button
           key={totalPages}
           onClick={() => handlePageChange(totalPages)}
-          className={`px-3 py-1 border rounded ${currentPage === totalPages ? 'bg-black text-white' : ''}`}
+          className={`px-3 py-1 border rounded border-gray-300 dark:border-gray-600 ${currentPage === totalPages ? 'bg-black text-white dark:bg-white dark:text-black' : ''}`}
         >
           {totalPages}
         </button>
@@ -113,24 +113,24 @@ export default function JobsPage() {
   };
 
   return (
-    <main className="max-w-5xl mx-auto px-4 py-8">
+    <main className="max-w-5xl mx-auto px-4 py-8 min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       {/* Removed the <h1> "Remote Jobs" */}
 
       {loading ? (
-        <p className="text-gray-600">Loading...</p>
+        <p className="text-gray-600 dark:text-gray-300">Loading...</p>
       ) : jobs.length === 0 ? (
-        <p className="text-red-500">No jobs found.</p>
+        <p className="text-red-500 dark:text-red-400">No jobs found.</p>
       ) : (
         <div className="flex flex-col gap-4 mb-8">
           {jobs.map((job) => {
             const isExpanded = expandedJobId === job.id;
 
             return (
-              <div
-                key={job.id}
-                onClick={() => toggleExpand(job.id)}
-                className="border rounded-xl p-4 cursor-pointer hover:shadow transition"
-              >
+                <div
+                  key={job.id}
+                  onClick={() => toggleExpand(job.id)}
+                  className="border border-gray-200 dark:border-gray-700 rounded-xl p-4 cursor-pointer hover:shadow transition bg-white dark:bg-gray-800"
+                >
                 <div className="flex justify-between items-center mb-2">
                   {/* Left side: Title and company logo */}
                   <div className="flex items-center gap-3">
@@ -145,14 +145,14 @@ export default function JobsPage() {
                   </div>
 
                   {/* Right side: publication date */}
-                  <span className="text-sm text-gray-500">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
                     {new Date(job.publication_date).toLocaleDateString()}
                   </span>
                 </div>
 
                 {/* Collapsed view info */}
-                {!isExpanded && (
-                  <div className="text-sm text-gray-600 flex flex-wrap gap-4">
+                  {!isExpanded && (
+                    <div className="text-sm text-gray-600 dark:text-gray-300 flex flex-wrap gap-4">
                     <span>{job.candidate_required_location}</span>
                     <span>{job.job_type}</span>
                     {job.salary && <span>{job.salary}</span>}
@@ -162,10 +162,10 @@ export default function JobsPage() {
                 {/* Expanded view */}
                 {isExpanded && (
                   <>
-                    <p className="text-gray-700 mt-2">
+                      <p className="text-gray-700 dark:text-gray-300 mt-2">
                       <strong>Company:</strong> {job.company_name}
                     </p>
-                    <p className="text-gray-700">
+                      <p className="text-gray-700 dark:text-gray-300">
                       <strong>Category:</strong> {job.category}
                     </p>
 
@@ -173,10 +173,10 @@ export default function JobsPage() {
                     {job.tags && job.tags.length > 0 && (
                       <div className="mt-2 flex flex-wrap gap-2">
                         {job.tags.map((tag, idx) => (
-                          <span
-                            key={idx}
-                            className="bg-gray-200 text-gray-700 text-xs px-2 py-1 rounded-full"
-                          >
+                            <span
+                              key={idx}
+                              className="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 text-xs px-2 py-1 rounded-full"
+                            >
                             {tag}
                           </span>
                         ))}
@@ -184,10 +184,10 @@ export default function JobsPage() {
                     )}
 
                     {/* Description */}
-                    <div
-                      className="mt-4 text-gray-700 max-h-96 overflow-auto"
-                      dangerouslySetInnerHTML={{ __html: job.description }}
-                    />
+                      <div
+                        className="mt-4 text-gray-700 dark:text-gray-300 max-h-96 overflow-auto"
+                        dangerouslySetInnerHTML={{ __html: job.description }}
+                      />
 
                     {/* Button */}
                     <div className="mt-4">
@@ -195,7 +195,7 @@ export default function JobsPage() {
                         href={job.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+                          className="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 transition"
                         onClick={(e) => e.stopPropagation()} // prevent card toggle on click
                       >
                         See the job posting
@@ -210,22 +210,22 @@ export default function JobsPage() {
       )}
 
       {/* Pagination Controls */}
-      <div className="flex justify-center items-center gap-2">
-        <button
-          onClick={() => handlePageChange(currentPage - 1)}
-          disabled={currentPage <= 1}
-          className="px-4 py-2 border rounded disabled:opacity-50"
-        >
+        <div className="flex justify-center items-center gap-2">
+          <button
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage <= 1}
+            className="px-4 py-2 border rounded border-gray-300 dark:border-gray-600 disabled:opacity-50"
+          >
           Previous
         </button>
 
         {renderPageNumbers()}
 
-        <button
-          onClick={() => handlePageChange(currentPage + 1)}
-          disabled={currentPage >= totalPages}
-          className="px-4 py-2 border rounded disabled:opacity-50"
-        >
+          <button
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage >= totalPages}
+            className="px-4 py-2 border rounded border-gray-300 dark:border-gray-600 disabled:opacity-50"
+          >
           Next
         </button>
       </div>

--- a/client/src/app/jobs/page.tsx
+++ b/client/src/app/jobs/page.tsx
@@ -1,10 +1,14 @@
 import React, { Suspense } from 'react';
 import JobsPage from './JobsClient';
+import Footer from "@/components/Footer";
 
 export default function Page() {
   return (
-    <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading jobs...</div>}>
-      <JobsPage />
-    </Suspense>
+    <>
+      <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading jobs...</div>}>
+        <JobsPage />
+      </Suspense>
+      <Footer />
+    </>
   );
 }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,7 +1,7 @@
 
 import type { Metadata } from "next";
 import "./globals.css";
-import Navbar from "@/components/navbar"; // ✅ New import
+import Navbar from "@/components/navbar"; // ✅ Modular header
 
 
 
@@ -17,10 +17,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
-        <Navbar /> {/* ✅ Modular header */}
-        
-        {children}
+      <body className="antialiased flex min-h-screen flex-col">
+        <Navbar />
+
+        <div className="flex-1">{children}</div>
       </body>
     </html>
   );

--- a/client/src/app/maptest/page.tsx
+++ b/client/src/app/maptest/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Map, { Marker, Popup } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
+import Footer from "@/components/Footer";
 
 const NUM_MARKERS = 100;
 
@@ -148,6 +149,7 @@ useEffect(() => {
   }, []);
 
   return (
+    <>
     <div className="relative w-full h-screen">
       <Map
         initialViewState={{
@@ -193,5 +195,7 @@ useEffect(() => {
       {/* Optional overlay for softness */}
       <div className="pointer-events-none absolute top-0 left-0 w-full h-full z-10 bg-gradient-to-b from-white/80 via-white/10 to-transparent" />
     </div>
+    <Footer />
+    </>
   );
 }

--- a/client/src/app/methodology/page.tsx
+++ b/client/src/app/methodology/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from "react";
+import Footer from "@/components/Footer";
 
 const dumpAsOf = process.env.NEXT_PUBLIC_DUMP_AS_OF ?? "N/A";
 const currentYear = new Date().getFullYear();
@@ -183,7 +184,8 @@ export default function MethodologyPage() {
   ];
 
   return (
-    <main className="mx-auto max-w-5xl px-4 py-10">
+    <>
+      <main className="mx-auto max-w-5xl px-4 py-10">
       <header className="mb-8">
         <h1 className="text-3xl font-semibold tracking-tight">Methodology</h1>
         <p className="mt-1 text-sm text-gray-600">
@@ -407,6 +409,8 @@ export default function MethodologyPage() {
         <span>© {currentYear} Sufoniq • Data snapshot: {dumpAsOf}</span>
         <a href="#ingestion" className="hover:text-slate-900">Back to top ↑</a>
       </footer>
-    </main>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/client/src/app/page.tsx
+++ b/client/src/app/page.tsx
@@ -13,43 +13,39 @@ const WorldMap = dynamic(() => import("@/components/WorldMap"), { ssr: false });
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-backgroundLight text-textLight dark:bg-backgroundDark dark:text-textDark relative">
-      
-      {/* Map Background for Hero */}
-      <div className="absolute top-0 left-0 w-full h-screen -z-10 opacity-40 pointer-events-none">
-        <WorldMap />
-      </div>
+    <>
+      <main className="min-h-screen bg-backgroundLight text-textLight dark:bg-backgroundDark dark:text-textDark relative">
+        {/* Map Background for Hero */}
+        <div className="absolute top-0 left-0 w-full h-screen -z-10 opacity-40 pointer-events-none">
+          <WorldMap />
+        </div>
 
-      {/* Hero Section */}
-      <section id="hero" className="h-[70vh] relative z-10 bg-transparent">
-        <Hero />
-      </section>
+        {/* Hero Section */}
+        <section id="hero" className="h-[70vh] relative z-10 bg-transparent">
+          <Hero />
+        </section>
 
-      {/* Search Me Section */}
-      <section id="search-me">
-        <SearchMe />
-      </section>
+        {/* Search Me Section */}
+        <section id="search-me">
+          <SearchMe />
+        </section>
 
-      {/* How It Works Section */}
-      <section id="how-it-works">
-        <HowItWorks />
-      </section>
-      
-      {/* Core Services Section */}
-      <section id="services">
-        <CoreServices />
-      </section>
-    
-      {/* Contact Section */}{/* How It Works Section */}
-      <section id="Contact">
-        <Contact />
-      </section>
+        {/* How It Works Section */}
+        <section id="how-it-works">
+          <HowItWorks />
+        </section>
 
+        {/* Core Services Section */}
+        <section id="services">
+          <CoreServices />
+        </section>
 
-      {/* Footer Section */}
-      <footer id="footer">
-        <Footer />
-      </footer>
-    </main>
+        {/* Contact Section */}
+        <section id="Contact">
+          <Contact />
+        </section>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -211,6 +211,9 @@ export default function Footer() {
             <li>
               <span className="font-semibold">MapLibre</span>: maps with open-source manners.
             </li>
+            <li>
+              <span className="font-semibold">World Bank API</span>: global development data.
+            </li>
           </ul>
         </motion.div>
 
@@ -224,7 +227,7 @@ export default function Footer() {
           <div>
             <p className="mb-4">Helping you relocate without rage-quitting since 2025.</p>
           </div>
-          <p className="text-xs text-gray-200">&copy; {new Date().getFullYear()} Inquos. All rights reserved.</p>
+          <p className="text-xs text-gray-200">&copy; 2025 Inquos. All rights reserved.</p>
         </motion.div>
       </div>
 


### PR DESCRIPTION
## Summary
- adjust country list cards for clearer text in dark theme
- update footer with Inquos copyright and World Bank API credit
- add World Bank API to technology partners on About page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abbe5162c88324a80d970f623511b8