### PR TITLE
Update footer branding and fix light mode styling

### DIFF
--- a/client/src/app/countries/page.tsx
+++ b/client/src/app/countries/page.tsx
@@ -225,7 +225,7 @@ export default function CountriesPage() {
                 onClick={() => toggle(group.id)}
                 aria-expanded={isOpen}
                 className={[
-                  'w-full rounded-xl p-4 border bg-gradient-to-r flex items-center gap-3 text-left',
+                  'w-full rounded-xl p-4 border bg-white bg-gradient-to-r flex items-center gap-3 text-left',
                   'transition focus:outline-none focus:ring-2',
                   accent.headerFrom, accent.headerTo, accent.ring,
                   'dark:from-gray-800 dark:to-gray-700 dark:border-gray-700',
@@ -251,7 +251,7 @@ export default function CountriesPage() {
                           'group rounded-2xl border p-4 shadow-sm transition focus:outline-none',
                           'hover:-translate-y-0.5 hover:shadow-md ring-1 ring-inset',
                           accent.ring,
-                          'bg-gradient-to-br',
+                          'bg-white bg-gradient-to-br',
                           accent.hoverFrom,
                           accent.hoverTo,
                           'dark:border-gray-700 dark:bg-gray-800 dark:hover:from-gray-700 dark:hover:to-gray-800',

--- a/client/src/app/country/[iso3]/page.tsx
+++ b/client/src/app/country/[iso3]/page.tsx
@@ -243,7 +243,7 @@ export default function CountryPage() {
               Data snapshot: {snapshot} • Dataset: World Bank (WDI & related)
             </div>
           </div>
-          <span className="ml-auto text-xs px-2 py-1 rounded-full border bg-white/70 dark:bg-gray-800 dark:border-gray-600">{iso3}</span>
+          <span className="ml-auto text-xs px-2 py-1 rounded-full border bg-white dark:bg-gray-800 dark:border-gray-600">{iso3}</span>
         </div>
         {data.summary_md ? (
           <p className="mt-4 text-gray-800 dark:text-gray-200 whitespace-pre-wrap">{data.summary_md}</p>
@@ -254,7 +254,7 @@ export default function CountryPage() {
       {factsOrdered.length ? (
         <section className="space-y-3">
           <h2 className="text-xl font-semibold">Headline KPIs (latest available)</h2>
-          <div className="overflow-auto rounded-2xl border bg-white/70 dark:bg-gray-800 dark:border-gray-700">
+          <div className="overflow-auto rounded-2xl border bg-white dark:bg-gray-800 dark:border-gray-700">
             <table className="min-w-full text-sm">
               <thead className="bg-gray-50 dark:bg-gray-700">
                 <tr className="text-left">
@@ -352,7 +352,7 @@ export default function CountryPage() {
               const title = k.replace('_', ' ').replace(/\b\w/g, (s) => s.toUpperCase());
 
               return (
-                <div key={k} className={`rounded-2xl border p-4 bg-white/70 dark:bg-gray-800 dark:border-gray-700 ring-1 ring-inset ${accent.ring} dark:ring-gray-700`}>
+                <div key={k} className={`rounded-2xl border p-4 bg-white dark:bg-gray-800 dark:border-gray-700 ring-1 ring-inset ${accent.ring} dark:ring-gray-700`}>
                   <div className="flex items-baseline justify-between mb-2">
                     <h3 className="font-medium">{title}</h3>
                     <div className="text-2xl font-semibold">{scoreText}</div>

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -224,7 +224,7 @@ export default function Footer() {
           <div>
             <p className="mb-4">Helping you relocate without rage-quitting since 2025.</p>
           </div>
-          <p className="text-xs text-gray-200">&copy; {new Date().getFullYear()} Inquos. All rights reserved.</p>
+          <p className="text-xs text-gray-200">&copy; {new Date().getFullYear()} UAB SkillAxis. All rights reserved.</p>
         </motion.div>
       </div>
 


### PR DESCRIPTION
## Summary
- Show company name UAB SkillAxis in footer
- Restore light theme backgrounds for country listings and details

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abca567e9c83248fcff21269b9aeb2