### PR TITLE
feat: add percentile slider navigation

### DIFF
--- a/client/src/app/country/[iso3]/page.tsx
+++ b/client/src/app/country/[iso3]/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Footer from "@/components/Footer";
+import { findNearestCountry } from "@/lib/percentiles";
 
 /** ---------- Types matching your narrative JSON ---------- */
 type Pctl = { world?: number; region?: number; income?: number };
@@ -172,6 +173,7 @@ async function fetchNameFromManifest(iso3: string): Promise<string | null> {
 export default function CountryPage() {
   const params = useParams<{ iso3: string }>();
   const iso3 = (params?.iso3 ?? '').toUpperCase();
+  const router = useRouter();
 
   const [data, setData] = useState<Narrative | null>(null);
   const [name, setName] = useState<string | null>(null);
@@ -294,11 +296,24 @@ export default function CountryPage() {
                           <span className={`inline-block text-xs px-2 py-0.5 rounded-full border ${accent.chip}`}>
                             {worldPctTxt}
                           </span>
-                            <div className="h-2 rounded bg-gray-200 dark:bg-gray-700 w-32 overflow-hidden">
+                          <div className="relative h-2 rounded bg-gray-200 dark:bg-gray-700 w-32 overflow-hidden">
                             <div
                               className={['h-2 rounded', accent.bar].join(' ')}
                               style={{ width: worldPctRaw != null ? `${Math.max(0, Math.min(100, worldPctRaw))}%` : '0%' }}
                               aria-label={`World percentile ${worldPctTxt}`}
+                            />
+                            <input
+                              type="range"
+                              min={0}
+                              max={100}
+                              step={1}
+                              defaultValue={worldPctRaw ?? 0}
+                              className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                              onChange={async (e) => {
+                                const target = Number(e.currentTarget.value);
+                                const iso = await findNearestCountry(f.code, target);
+                                if (iso && iso !== iso3) router.push(`/country/${iso.toUpperCase()}`);
+                              }}
                             />
                           </div>
                         </div>

--- a/client/src/lib/percentiles.ts
+++ b/client/src/lib/percentiles.ts
@@ -1,0 +1,56 @@
+export type PercentileEntry = { iso3: string; pctl: number };
+export type PercentileMap = Record<string, PercentileEntry[]>;
+
+let cache: PercentileMap | null = null;
+
+async function loadAll(): Promise<PercentileMap> {
+  if (cache) return cache;
+  try {
+    const idxResp = await fetch('/data/v1/index.json', { cache: 'force-cache' });
+    if (!idxResp.ok) return {};
+    const idx = await idxResp.json() as { countries?: { iso3?: string; files?: { narrative?: string } }[] };
+    const countries = idx.countries ?? [];
+    const results: PercentileMap = {};
+    await Promise.all(
+      countries.map(async (c) => {
+        const iso3 = c.iso3;
+        const url = c.files?.narrative;
+        if (!iso3 || !url) return;
+        try {
+          const r = await fetch(url, { cache: 'force-cache' });
+          if (!r.ok) return;
+          const data = await r.json() as { facts_used?: { code?: string; pctl?: { world?: number } }[] };
+          for (const f of data.facts_used ?? []) {
+            const code = f.code;
+            const pct = f.pctl?.world;
+            if (!code || typeof pct !== 'number') continue;
+            if (!results[code]) results[code] = [];
+            results[code]!.push({ iso3, pctl: pct });
+          }
+        } catch {
+          /* ignore failed fetch */
+        }
+      })
+    );
+    cache = results;
+    return results;
+  } catch {
+    return {};
+  }
+}
+
+export async function findNearestCountry(code: string, target: number): Promise<string | null> {
+  const map = await loadAll();
+  const list = map[code];
+  if (!list || !list.length) return null;
+  let best = list[0];
+  let bestDiff = Math.abs(list[0].pctl - target);
+  for (const item of list) {
+    const diff = Math.abs(item.pctl - target);
+    if (diff < bestDiff) {
+      best = item;
+      bestDiff = diff;
+    }
+  }
+  return best.iso3;
+}


### PR DESCRIPTION
## Summary
- allow sliding KPI percentile bars to jump between countries
- load all country percentiles and find closest match

## Testing
- `npm run lint`
- `npm run build` *(fails: MONGODB_URI is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68abdfac75f8832485bb9549b0dd9a6d