### PR TITLE
Handle contact form submissions via Resend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # webappin
+
+## Environment variables
+
+Configure the following variables for the Next.js client (e.g., in `client/.env.local` for local development or in your deployment platform settings):
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `RESEND_API_KEY` | ✅ | API key used by the contact form endpoint to authenticate with Resend. |
+| `RESEND_FROM_ADDRESS` | ⛔️ (optional) | Verified sender email address used for outbound messages. Defaults to `Sufoniq <no-reply@sufoniq.com>`. |
+
+After setting or changing these values, restart the Next.js server so the environment is reloaded.
  

--- a/client/src/app/api/contact/route.ts
+++ b/client/src/app/api/contact/route.ts
@@ -1,15 +1,40 @@
 // app/api/contact/route.ts (Next.js 13+ / App Router)
 import { NextResponse } from "next/server";
+import { Resend } from "resend";
 
 export async function POST(req: Request) {
-  const { name, email, subject, message } = await req.json();
+  let payload: { name?: string; email?: string; subject?: string; message?: string };
+  try {
+    payload = await req.json();
+  } catch (error) {
+    console.error("Invalid contact form payload", error);
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
 
-  // TODO: send email to support@sufoniq.com with your provider of choice.
-  // Example: await resend.emails.send({...})
+  const { name, email, subject, message } = payload;
 
   // Basic guard:
   if (!name || !email || !subject || !message) {
     return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  if (!process.env.RESEND_API_KEY) {
+    return NextResponse.json({ error: "Email service not configured" }, { status: 500 });
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  try {
+    await resend.emails.send({
+      from: process.env.RESEND_FROM_ADDRESS ?? "Sufoniq <no-reply@sufoniq.com>",
+      to: "support@sufoniq.com",
+      replyTo: email,
+      subject,
+      text: `New contact form submission\n\nName: ${name}\nEmail: ${email}\nSubject: ${subject}\n\n${message}`,
+    });
+  } catch (error) {
+    console.error("Failed to deliver contact form email", error);
+    return NextResponse.json({ error: "Failed to send message" }, { status: 500 });
   }
 
   return NextResponse.json({ ok: true }, { status: 200 });

--- a/client/src/components/Contact.tsx
+++ b/client/src/components/Contact.tsx
@@ -125,10 +125,33 @@ export default function ContactReproPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (submitting) return;
     setSubmitting(true);
-    await new Promise((r) => setTimeout(r, 600));
-    setSubmitting(false);
-    setShowForm(false);
+    try {
+      const response = await fetch("/api/contact", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(form),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error ?? "We couldn’t send your message. Please try again.";
+        window.alert(message);
+        return;
+      }
+
+      setForm({ name: "", email: "", subject: "", message: "" });
+      setShowForm(false);
+      window.alert("Message sent! We’ll get back to you soon.");
+    } catch (error) {
+      console.error("Failed to send contact form", error);
+      window.alert("We couldn’t send your message. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- wire the contact form UI to POST to the contact API and display success or failure to the user
- implement the contact API route to send emails through Resend and report configuration or delivery errors
- document the required Resend environment variables for local and deployed environments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dce69b83608324a0b01bbed1992116