### PR TITLE
Fix lint warnings across jobs and map pages

### DIFF
--- a/client/src/app/jobs/JobsClient.tsx
+++ b/client/src/app/jobs/JobsClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import Image from 'next/image';
 import { useSearchParams, useRouter } from 'next/navigation';
 
 type Job = {
@@ -95,6 +96,7 @@ export default function JobsPage() {
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
   const [pageSize, setPageSize] = useState(currentLimit);
   const [modalJob, setModalJob] = useState<Job | null>(null);
+  const [logoOverrides, setLogoOverrides] = useState<Record<string, string>>({});
 
   const [qInput, setQInput] = useState(currentQ);
   const [sourceInput, setSourceInput] = useState(currentSource);
@@ -199,7 +201,8 @@ export default function JobsPage() {
           {jobs.map((job) => {
             const isExpanded = expandedJobId === job.id;
             const bannerText = job.source ? `Source: ${job.source}` : 'Source: External';
-            const logoSrc = job.company_logo || logoFallback(job.company_domain, job.company_name);
+            const defaultLogo = job.company_logo || logoFallback(job.company_domain, job.company_name);
+            const logoSrc = logoOverrides[job.id] ?? defaultLogo;
 
             return (
               <div
@@ -215,11 +218,18 @@ export default function JobsPage() {
                 <button onClick={() => toggleExpand(job.id)} className="w-full text-left">
                   <div className="flex justify-between items-start gap-3">
                     <div className="flex items-center gap-3">
-                      <img
+                      <Image
                         src={logoSrc}
                         alt={`${job.company_name} logo`}
+                        width={40}
+                        height={40}
                         className="w-10 h-10 object-contain rounded"
-                        onError={(e) => { (e.currentTarget as HTMLImageElement).src = logoFallback(job.company_domain, job.company_name); }}
+                        unoptimized
+                        onError={() => {
+                          const fallback = logoFallback(job.company_domain, job.company_name);
+                          if (logoSrc === fallback) return;
+                          setLogoOverrides((prev) => ({ ...prev, [job.id]: fallback }));
+                        }}
                       />
                       <div>
                         <h2 className="text-xl font-semibold text-primary">{job.title}</h2>

--- a/client/src/app/maptest/page.tsx
+++ b/client/src/app/maptest/page.tsx
@@ -7,29 +7,7 @@ import Footer from "@/components/Footer";
 
 const NUM_MARKERS = 100;
 
-function getSmartCoordinates(): [number, number] {
-  const lat = Math.random() * 120 - 50;
-  const lng = Math.random() * 360 - 180;
-  return [lng, lat];
-}
-
-function jitter([lng, lat]: [number, number]): [number, number] {
-  const deltaLat = (Math.random() - 0.5) * 0.2;
-  const deltaLng = (Math.random() - 0.5) * 0.2;
-  return [lng + deltaLng, lat + deltaLat];
-}
-
-export default function MapTest() {
-  const [positions, setPositions] = useState(
-    Array.from({ length: NUM_MARKERS }, (_, i) => ({
-      id: i,
-      coordinates: getSmartCoordinates(),
-    }))
-  );
-
-  const [popupIndex, setPopupIndex] = useState<number | null>(null);
-
-  const popupFacts = [
+const popupFacts: string[] = [
   "🌉 Tokyo: Tokyo has the world’s busiest pedestrian crossing at Shibuya, where up to 3,000 people cross at once during peak times. Japan has more pets than children, with around 17 million pets compared to 15 million children under 15 years old.",
   "🚇 Delhi: Delhi’s metro system is the world’s longest operational metro network in a single country. India hosts the Kumbh Mela, the largest human gathering on Earth, attracting over 100 million people over weeks.",
   "🏦 Shanghai: Shanghai’s Bund was nicknamed the “Wall Street of the East” for its 1920s financial importance. China owns the world’s largest high-speed rail network — more than 40,000 km.",
@@ -58,80 +36,112 @@ export default function MapTest() {
 ];
 
 const factCoordinates: [number, number][] = [
-  [139.6917, 35.6895],   // Tokyo
-  [77.1025, 28.7041],    // Delhi
-  [121.4737, 31.2304],   // Shanghai
-  [-46.6333, -23.5505],  // São Paulo
-  [-99.1332, 19.4326],   // Mexico City
-  [31.2357, 30.0444],    // Cairo
-  [72.8777, 19.076],     // Mumbai
-  [116.4074, 39.9042],   // Beijing
-  [90.4125, 23.8103],    // Dhaka
-  [135.5023, 34.6937],   // Osaka
-  [-73.935242, 40.73061],// New York City
-  [66.9905, 24.8607],    // Karachi
-  [-58.4173, -34.6118],  // Buenos Aires
-  [106.5516, 29.563],    // Chongqing
-  [28.9784, 41.0082],    // Istanbul
-  [88.3639, 22.5726],    // Kolkata
-  [120.9842, 14.5995],   // Manila
-  [3.3792, 6.5244],      // Lagos
-  [-43.1729, -22.9068],  // Rio de Janeiro
-  [117.3616, 39.3434],   // Tianjin
-  [15.2663, -4.4419],    // Kinshasa
-  [113.2644, 23.1291],   // Guangzhou
-  [-118.2437, 34.0522],  // Los Angeles
-  [37.6173, 55.7558],    // Moscow
-  [114.0579, 22.5431],   // Shenzhen
+  [139.6917, 35.6895], // Tokyo
+  [77.1025, 28.7041], // Delhi
+  [121.4737, 31.2304], // Shanghai
+  [-46.6333, -23.5505], // São Paulo
+  [-99.1332, 19.4326], // Mexico City
+  [31.2357, 30.0444], // Cairo
+  [72.8777, 19.076], // Mumbai
+  [116.4074, 39.9042], // Beijing
+  [90.4125, 23.8103], // Dhaka
+  [135.5023, 34.6937], // Osaka
+  [-73.935242, 40.73061], // New York City
+  [66.9905, 24.8607], // Karachi
+  [-58.4173, -34.6118], // Buenos Aires
+  [106.5516, 29.563], // Chongqing
+  [28.9784, 41.0082], // Istanbul
+  [88.3639, 22.5726], // Kolkata
+  [120.9842, 14.5995], // Manila
+  [3.3792, 6.5244], // Lagos
+  [-43.1729, -22.9068], // Rio de Janeiro
+  [117.3616, 39.3434], // Tianjin
+  [15.2663, -4.4419], // Kinshasa
+  [113.2644, 23.1291], // Guangzhou
+  [-118.2437, 34.0522], // Los Angeles
+  [37.6173, 55.7558], // Moscow
+  [114.0579, 22.5431], // Shenzhen
 ];
 
-useEffect(() => {
-  // Helper: Fisher-Yates shuffle to randomize popup order each cycle
-  function shuffleArray(arr: number[]) {
-    const array = [...arr];
-    for (let i = array.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [array[i], array[j]] = [array[j], array[i]];
-    }
-    return array;
-  }
+function getSmartCoordinates(): [number, number] {
+  const lat = Math.random() * 120 - 50;
+  const lng = Math.random() * 360 - 180;
+  return [lng, lat];
+}
 
-  const customTimings = [
-    { delayBeforeShow: 2000, visibleDuration: 5000 }, // 1st popup: delay 2s, visible 2.5s
-    { delayBeforeShow: 2000, visibleDuration: 5000 }, // 2nd popup: delay 2s, visible 3s
-    { delayBeforeShow: 3000, visibleDuration: 5000 }, // 3rd popup: delay 3s, visible 2s
-  ];
+function jitter([lng, lat]: [number, number]): [number, number] {
+  const deltaLat = (Math.random() - 0.5) * 0.2;
+  const deltaLng = (Math.random() - 0.5) * 0.2;
+  return [lng + deltaLng, lat + deltaLat];
+}
 
-  let popupOrder = shuffleArray(popupFacts.map((_, i) => i));
-  let index = 0;
+export default function MapTest() {
+  const [positions, setPositions] = useState(
+    Array.from({ length: NUM_MARKERS }, (_, i) => ({
+      id: i,
+      coordinates: getSmartCoordinates(),
+    }))
+  );
 
-  const cyclePopups = () => {
-    const currentPopup = popupOrder[index];
-    setPopupIndex(currentPopup);
+  const [popupIndex, setPopupIndex] = useState<number | null>(null);
 
-    const isFirstThree = index < 3;
-    const { delayBeforeShow, visibleDuration } = isFirstThree
-      ? customTimings[index]
-      : {
-          delayBeforeShow: 5000 + Math.random() * 2000, // random between 3-5 seconds
-          visibleDuration: 5000,
-        };
-
-    setTimeout(() => {
-      setPopupIndex(null);
-
-      index++;
-      if (index >= popupOrder.length) {
-        popupOrder = shuffleArray(popupFacts.map((_, i) => i)); // reshuffle on full cycle
-        index = 0;
+  useEffect(() => {
+    // Helper: Fisher-Yates shuffle to randomize popup order each cycle
+    function shuffleArray(arr: number[]) {
+      const array = [...arr];
+      for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
       }
+      return array;
+    }
 
-      setTimeout(cyclePopups, delayBeforeShow);
-    }, visibleDuration);
-  };
+    const customTimings = [
+      { delayBeforeShow: 2000, visibleDuration: 5000 }, // 1st popup: delay 2s, visible 2.5s
+      { delayBeforeShow: 2000, visibleDuration: 5000 }, // 2nd popup: delay 2s, visible 3s
+      { delayBeforeShow: 3000, visibleDuration: 5000 }, // 3rd popup: delay 3s, visible 2s
+    ];
 
-  cyclePopups();
-}, []);
+    let popupOrder = shuffleArray(popupFacts.map((_, i) => i));
+    let index = 0;
+    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const id = setTimeout(callback, delay);
+      timeoutIds.push(id);
+      return id;
+    };
+
+    const cyclePopups = () => {
+      const currentPopup = popupOrder[index];
+      setPopupIndex(currentPopup);
+
+      const isFirstThree = index < 3;
+      const { delayBeforeShow, visibleDuration } = isFirstThree
+        ? customTimings[index]
+        : {
+            delayBeforeShow: 5000 + Math.random() * 2000, // random between 3-5 seconds
+            visibleDuration: 5000,
+          };
+
+      scheduleTimeout(() => {
+        setPopupIndex(null);
+
+        index++;
+        if (index >= popupOrder.length) {
+          popupOrder = shuffleArray(popupFacts.map((_, i) => i)); // reshuffle on full cycle
+          index = 0;
+        }
+
+        scheduleTimeout(cyclePopups, delayBeforeShow);
+      }, visibleDuration);
+    };
+
+    cyclePopups();
+    return () => {
+      timeoutIds.forEach((id) => clearTimeout(id));
+    };
+  }, []);
 
 
 

--- a/client/src/app/terms-conditions/page.tsx
+++ b/client/src/app/terms-conditions/page.tsx
@@ -175,7 +175,7 @@ export default function TermsAndConditionsPage() {
         <section id="your-content" className="space-y-4">
           <h2 className="text-2xl font-semibold">7) Your Content & Licenses</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li>You retain ownership of content you upload ("Your Content").</li>
+            <li>You retain ownership of content you upload (&ldquo;Your Content&rdquo;).</li>
             <li>You grant {COMPANY_LEGAL} a worldwide, non‑exclusive, royalty‑free license to host, process, transmit, reproduce, and display Your Content solely to operate, secure, maintain, and improve the Services, and to comply with law. We do not sell Your Content.</li>
             <li>You warrant you have all rights necessary and that Your Content does not infringe third‑party rights.</li>
             <li><strong>Feedback.</strong> You grant us a perpetual, irrevocable, royalty‑free license to use suggestions without restriction.</li>

--- a/client/src/components/WorldMap.tsx
+++ b/client/src/components/WorldMap.tsx
@@ -6,29 +6,7 @@ import "maplibre-gl/dist/maplibre-gl.css";
 
 const NUM_MARKERS = 100;
 
-function getSmartCoordinates(): [number, number] {
-  const lat = Math.random() * 120 - 50;
-  const lng = Math.random() * 360 - 180;
-  return [lng, lat];
-}
-
-function jitter([lng, lat]: [number, number]): [number, number] {
-  const deltaLat = (Math.random() - 0.5) * 0.2;
-  const deltaLng = (Math.random() - 0.5) * 0.2;
-  return [lng + deltaLng, lat + deltaLat];
-}
-
-export default function MapTest() {
-  const [positions, setPositions] = useState(
-    Array.from({ length: NUM_MARKERS }, (_, i) => ({
-      id: i,
-      coordinates: getSmartCoordinates(),
-    }))
-  );
-
-  const [popupIndex, setPopupIndex] = useState<number | null>(null);
-
-  const popupFacts = [
+const popupFacts: string[] = [
   "🌉 Tokyo: Tokyo has the world’s busiest pedestrian crossing at Shibuya, where up to 3,000 people cross at once during peak times. Japan has more pets than children, with around 17 million pets compared to 15 million children under 15 years old.",
   "🚇 Delhi: Delhi’s metro system is the world’s longest operational metro network in a single country. India hosts the Kumbh Mela, the largest human gathering on Earth, attracting over 100 million people over weeks.",
   "🏦 Shanghai: Shanghai’s Bund was nicknamed the “Wall Street of the East” for its 1920s financial importance. China owns the world’s largest high-speed rail network — more than 40,000 km.",
@@ -57,80 +35,112 @@ export default function MapTest() {
 ];
 
 const factCoordinates: [number, number][] = [
-  [139.6917, 35.6895],   // Tokyo
-  [77.1025, 28.7041],    // Delhi
-  [121.4737, 31.2304],   // Shanghai
-  [-46.6333, -23.5505],  // São Paulo
-  [-99.1332, 19.4326],   // Mexico City
-  [31.2357, 30.0444],    // Cairo
-  [72.8777, 19.076],     // Mumbai
-  [116.4074, 39.9042],   // Beijing
-  [90.4125, 23.8103],    // Dhaka
-  [135.5023, 34.6937],   // Osaka
-  [-73.935242, 40.73061],// New York City
-  [66.9905, 24.8607],    // Karachi
-  [-58.4173, -34.6118],  // Buenos Aires
-  [106.5516, 29.563],    // Chongqing
-  [28.9784, 41.0082],    // Istanbul
-  [88.3639, 22.5726],    // Kolkata
-  [120.9842, 14.5995],   // Manila
-  [3.3792, 6.5244],      // Lagos
-  [-43.1729, -22.9068],  // Rio de Janeiro
-  [117.3616, 39.3434],   // Tianjin
-  [15.2663, -4.4419],    // Kinshasa
-  [113.2644, 23.1291],   // Guangzhou
-  [-118.2437, 34.0522],  // Los Angeles
-  [37.6173, 55.7558],    // Moscow
-  [114.0579, 22.5431],   // Shenzhen
+  [139.6917, 35.6895], // Tokyo
+  [77.1025, 28.7041], // Delhi
+  [121.4737, 31.2304], // Shanghai
+  [-46.6333, -23.5505], // São Paulo
+  [-99.1332, 19.4326], // Mexico City
+  [31.2357, 30.0444], // Cairo
+  [72.8777, 19.076], // Mumbai
+  [116.4074, 39.9042], // Beijing
+  [90.4125, 23.8103], // Dhaka
+  [135.5023, 34.6937], // Osaka
+  [-73.935242, 40.73061], // New York City
+  [66.9905, 24.8607], // Karachi
+  [-58.4173, -34.6118], // Buenos Aires
+  [106.5516, 29.563], // Chongqing
+  [28.9784, 41.0082], // Istanbul
+  [88.3639, 22.5726], // Kolkata
+  [120.9842, 14.5995], // Manila
+  [3.3792, 6.5244], // Lagos
+  [-43.1729, -22.9068], // Rio de Janeiro
+  [117.3616, 39.3434], // Tianjin
+  [15.2663, -4.4419], // Kinshasa
+  [113.2644, 23.1291], // Guangzhou
+  [-118.2437, 34.0522], // Los Angeles
+  [37.6173, 55.7558], // Moscow
+  [114.0579, 22.5431], // Shenzhen
 ];
 
-useEffect(() => {
-  // Helper: Fisher-Yates shuffle to randomize popup order each cycle
-  function shuffleArray(arr: number[]) {
-    const array = [...arr];
-    for (let i = array.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [array[i], array[j]] = [array[j], array[i]];
-    }
-    return array;
-  }
+function getSmartCoordinates(): [number, number] {
+  const lat = Math.random() * 120 - 50;
+  const lng = Math.random() * 360 - 180;
+  return [lng, lat];
+}
 
-  const customTimings = [
-    { delayBeforeShow: 2000, visibleDuration: 5000 }, // 1st popup: delay 2s, visible 2.5s
-    { delayBeforeShow: 2000, visibleDuration: 5000 }, // 2nd popup: delay 2s, visible 3s
-    { delayBeforeShow: 3000, visibleDuration: 5000 }, // 3rd popup: delay 3s, visible 2s
-  ];
+function jitter([lng, lat]: [number, number]): [number, number] {
+  const deltaLat = (Math.random() - 0.5) * 0.2;
+  const deltaLng = (Math.random() - 0.5) * 0.2;
+  return [lng + deltaLng, lat + deltaLat];
+}
 
-  let popupOrder = shuffleArray(popupFacts.map((_, i) => i));
-  let index = 0;
+export default function MapTest() {
+  const [positions, setPositions] = useState(
+    Array.from({ length: NUM_MARKERS }, (_, i) => ({
+      id: i,
+      coordinates: getSmartCoordinates(),
+    }))
+  );
 
-  const cyclePopups = () => {
-    const currentPopup = popupOrder[index];
-    setPopupIndex(currentPopup);
+  const [popupIndex, setPopupIndex] = useState<number | null>(null);
 
-    const isFirstThree = index < 3;
-    const { delayBeforeShow, visibleDuration } = isFirstThree
-      ? customTimings[index]
-      : {
-          delayBeforeShow: 5000 + Math.random() * 2000, // random between 3-5 seconds
-          visibleDuration: 5000,
-        };
-
-    setTimeout(() => {
-      setPopupIndex(null);
-
-      index++;
-      if (index >= popupOrder.length) {
-        popupOrder = shuffleArray(popupFacts.map((_, i) => i)); // reshuffle on full cycle
-        index = 0;
+  useEffect(() => {
+    // Helper: Fisher-Yates shuffle to randomize popup order each cycle
+    function shuffleArray(arr: number[]) {
+      const array = [...arr];
+      for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
       }
+      return array;
+    }
 
-      setTimeout(cyclePopups, delayBeforeShow);
-    }, visibleDuration);
-  };
+    const customTimings = [
+      { delayBeforeShow: 2000, visibleDuration: 5000 }, // 1st popup: delay 2s, visible 2.5s
+      { delayBeforeShow: 2000, visibleDuration: 5000 }, // 2nd popup: delay 2s, visible 3s
+      { delayBeforeShow: 3000, visibleDuration: 5000 }, // 3rd popup: delay 3s, visible 2s
+    ];
 
-  cyclePopups();
-}, []);
+    let popupOrder = shuffleArray(popupFacts.map((_, i) => i));
+    let index = 0;
+    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const id = setTimeout(callback, delay);
+      timeoutIds.push(id);
+      return id;
+    };
+
+    const cyclePopups = () => {
+      const currentPopup = popupOrder[index];
+      setPopupIndex(currentPopup);
+
+      const isFirstThree = index < 3;
+      const { delayBeforeShow, visibleDuration } = isFirstThree
+        ? customTimings[index]
+        : {
+            delayBeforeShow: 5000 + Math.random() * 2000, // random between 3-5 seconds
+            visibleDuration: 5000,
+          };
+
+      scheduleTimeout(() => {
+        setPopupIndex(null);
+
+        index++;
+        if (index >= popupOrder.length) {
+          popupOrder = shuffleArray(popupFacts.map((_, i) => i)); // reshuffle on full cycle
+          index = 0;
+        }
+
+        scheduleTimeout(cyclePopups, delayBeforeShow);
+      }, visibleDuration);
+    };
+
+    cyclePopups();
+    return () => {
+      timeoutIds.forEach((id) => clearTimeout(id));
+    };
+  }, []);
 
 
 


### PR DESCRIPTION
## Summary
- replace the jobs page logo `<img>` element with `next/image` and add a fallback map to satisfy Next.js linting
- hoist map popup data/constants and add timeout cleanup so map pages pass the exhaustive-deps rule
- escape quotes in the terms page so copy renders without triggering the unescaped-entities rule

## Testing
- yarn build *(fails: Missing API key. Pass it to the constructor `new Resend("re_123")`)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc40abf988324b86e57b6c16e6894